### PR TITLE
Fix forward slash in $valueName

### DIFF
--- a/Common.ps1
+++ b/Common.ps1
@@ -566,8 +566,9 @@ function ParseKeyValueName
     }
     else
     {
-        $key       = Split-Path $KeyValueName -Parent
-        $valueName = Split-Path $KeyValueName -Leaf
+        $KeyValueNameArray = $KeyValueName.split("\")
+        $key               = $KeyValueNameArray[0..($KeyValueNameArray.Count-2)] -join "\"
+        $valueName         = $KeyValueNameArray[-1]
     }
 
     return $key, $valueName


### PR DESCRIPTION
The following DSC code doesn't work because there are forward slashes in the KeyValueName:
```
cAdministrativeTemplateSetting test
{
		Ensure = "Present"
		PolicyType = "Machine"
		KeyValueName = "Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\ZoneMapKey\https://*.example.com"
		Type = "String"
		Data = "2"
}
```

The code before this change split the above code in the following:
```
$key       = "Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\ZoneMapKey\https:\"
$valueName = "*.example.com"
```

But it should be:
```
$key       = "Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\ZoneMapKey"
$valueName = "https://*.example.com"
```