### PR TITLE
Fix Invoke-DscResource

### DIFF
--- a/DscResources/PshOrg_AccountAdminTemplateSetting/PshOrg_AccountAdminTemplateSetting.schema.mof
+++ b/DscResources/PshOrg_AccountAdminTemplateSetting/PshOrg_AccountAdminTemplateSetting.schema.mof
@@ -5,6 +5,6 @@ class PshOrg_AccountAdminTemplateSetting : OMI_BaseResource
 [Key] string KeyValueName;
 [write,ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] string Ensure;
 [write] string Data[];
-[write,ValueMap{"0","1","2","3","4","7","11","-1"},Values{"Unknown","String","ExpandString","Binary","DWord","MultiString","QWord","None"}] sint32 Type;
+[write,ValueMap{"Unknown", "String", "ExpandString", "Binary", "DWord", "MultiString", "QWord", "None"},Values{"Unknown","String","ExpandString","Binary","DWord","MultiString","QWord","None"}] string Type;
 };
 

--- a/DscResources/PshOrg_AdminTemplateSetting/PshOrg_AdminTemplateSetting.schema.mof
+++ b/DscResources/PshOrg_AdminTemplateSetting/PshOrg_AdminTemplateSetting.schema.mof
@@ -5,6 +5,6 @@ class PshOrg_AdminTemplateSetting : OMI_BaseResource
 [Key] string KeyValueName;
 [write,ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] string Ensure;
 [write] string Data[];
-[write,ValueMap{"0","1","2","3","4","7","11","-1"},Values{"Unknown","String","ExpandString","Binary","DWord","MultiString","QWord","None"}] sint32 Type;
+[write,ValueMap{"Unknown", "String", "ExpandString", "Binary", "DWord", "MultiString", "QWord", "None"},Values{"Unknown","String","ExpandString","Binary","DWord","MultiString","QWord","None"}] string Type;
 };
 


### PR DESCRIPTION
Fixes https://github.com/dlwyatt/PolicyFileEditor/issues/5.

Before this change this works for Invoke-DscResource:
```
$DscParams = @{}
$DscParams.Add("Ensure", "Present")
$DscParams.Add("KeyValueName", "'SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services\LicenseServers")
$DscParams.Add("PolicyType", "Machine")
$DscParams.Add("Data", @("something.contoso.com"))
$DscParams.Add("Type", 1)
Invoke-DscResource -Name cAdministrativeTemplateSetting -ModuleName "PolicyFileEditor" -Method Test -Property $dscparams
```

After this change this works:
```
$DscParams = @{}
$DscParams.Add("Ensure", "Present")
$DscParams.Add("KeyValueName", "'SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services\LicenseServers")
$DscParams.Add("PolicyType", "Machine")
$DscParams.Add("Data", @("something.contoso.com"))
$DscParams.Add("Type", "String")
Invoke-DscResource -Name cAdministrativeTemplateSetting -ModuleName "PolicyFileEditor" -Method Test -Property $dscparams
```

It saves the strange type conversion and makes it more consistent.